### PR TITLE
Count feedbacks since the beginning of the week

### DIFF
--- a/lib/corker/slack/actions/high_five.ex
+++ b/lib/corker/slack/actions/high_five.ex
@@ -32,11 +32,11 @@ defmodule Corker.Slack.Actions.HighFive do
       reason: reason
     })
 
-    one_week_ago = Timex.now() |> Timex.shift(weeks: -1)
+    beginning_of_week = Timex.now() |> Timex.beginning_of_week(:mon)
 
     high_five_count =
       receiver_id
-      |> Feedback.high_fives_since(one_week_ago)
+      |> Feedback.high_fives_since(beginning_of_week)
       |> length
 
     reply =


### PR DESCRIPTION
Why:

* Currently we are going back 7 days.
* As stats go, this isn't really interesting. Our scheduling unit is the
work week, not a rolling 7 days period.

This change addresses the need by:

* Retrieving high five counts since the most recent Monday.