### PR TITLE
Reduce the number of user tags.

### DIFF
--- a/config/messages.yml
+++ b/config/messages.yml
@@ -1,6 +1,6 @@
 high_five:
   created:
-    "Hell yeah! High five created! <@<%= receiver_id %>> has received <%= high_five_count %> high fives this week"
+    "Hell yeah! High five created! <%= receiver_username %> has received <%= high_five_count %> high fives this week"
 
 error:
   dm_received:

--- a/lib/corker/slack/actions/high_five.ex
+++ b/lib/corker/slack/actions/high_five.ex
@@ -22,26 +22,30 @@ defmodule Corker.Slack.Actions.HighFive do
     end
   end
 
-  defp do_run(receiver: receiver, reason: reason, sender: sender) do
-    sender_id = Accounts.find_by(slack_id: sender).id
-    receiver_id = Accounts.find_by(slack_id: receiver).id
+  defp do_run(
+         receiver: receiver_slack_id,
+         reason: reason,
+         sender: sender_slack_id
+       ) do
+    sender = Accounts.find_by(slack_id: sender_slack_id)
+    receiver = Accounts.find_by(slack_id: receiver_slack_id)
 
     Feedback.create_high_five(%{
-      sender_id: sender_id,
-      receiver_id: receiver_id,
+      sender_id: sender.id,
+      receiver_id: receiver.id,
       reason: reason
     })
 
     beginning_of_week = Timex.now() |> Timex.beginning_of_week(:mon)
 
     high_five_count =
-      receiver_id
+      receiver.id
       |> Feedback.high_fives_since(beginning_of_week)
       |> length
 
     reply =
       Messages.t("high_five.created",
-        receiver_id: receiver,
+        receiver_username: receiver.username,
         high_five_count: high_five_count
       )
 

--- a/test/corker/slack/actions/high_five_test.exs
+++ b/test/corker/slack/actions/high_five_test.exs
@@ -40,7 +40,7 @@ defmodule Corker.Slack.Actions.HighFiveTest do
 
       reply =
         Messages.t("high_five.created",
-          receiver_id: receiver.slack_id,
+          receiver_username: receiver.username,
           high_five_count: 2
         )
 


### PR DESCRIPTION
We are tagging users to send them high fives. Reduce that by using the
username and not the actual tag.