### PR TITLE
Adds high five listing command

### DIFF
--- a/config/messages.yml
+++ b/config/messages.yml
@@ -1,6 +1,8 @@
 high_five:
   created:
     "Hell yeah! High five created! <%= receiver_username %> has received <%= high_five_count %> high fives this week"
+  list:
+    "Sure thing. Here are your high fives since Monday:\n<%= high_fives %>"
 
 error:
   dm_received:

--- a/lib/corker/slack/actions.ex
+++ b/lib/corker/slack/actions.ex
@@ -1,8 +1,12 @@
 defmodule Corker.Slack.Actions do
   alias Corker.Slack.Messages
 
-  @actions [
+  @public_channel_actions [
     __MODULE__.HighFive
+  ]
+
+  @dm_actions [
+    __MODULE__.WeeklyList
   ]
 
   # we don't care about control-style messages,
@@ -12,21 +16,26 @@ defmodule Corker.Slack.Actions do
 
   # this is how slack distinguishes channel messages from DMs:
   # by setting the channel id to start with a D
-  def parse(%{channel: "D" <> _}, _) do
-    {:reply, Messages.t("error.dm_received")}
+  def parse(%{channel: "D" <> _} = message, _) do
+    error_msg = Messages.t("error.dm_received")
+    run_actions(@dm_actions, message, error_msg)
   end
 
   def parse(%{text: text} = message, %{id: id}) do
     case Regex.run(~r/^<@#{id}>\s+(.*)/, text) do
-      nil -> :noreply
-      [_, _] -> run_command(message)
+      nil ->
+        :noreply
+
+      [_, _] ->
+        error_msg = Messages.t("error.unknown_command")
+        run_actions(@public_channel_actions, message, error_msg)
     end
   end
 
-  defp run_command(message) do
+  defp run_actions(actions, message, default_response) do
     Enum.reduce_while(
-      @actions,
-      {:reply, Messages.t("error.unknown_command")},
+      actions,
+      {:reply, default_response},
       fn action, acc ->
         case action.run(message) do
           nil -> {:cont, acc}

--- a/lib/corker/slack/actions/weekly_list.ex
+++ b/lib/corker/slack/actions/weekly_list.ex
@@ -1,0 +1,41 @@
+defmodule Corker.Slack.Actions.WeeklyList do
+  @cmd_regex ~r/(list my high fives)/
+
+  alias Corker.Slack.Messages
+
+  alias Corker.{
+    Accounts,
+    Feedback
+  }
+
+  def run(%{text: text, user: user}) do
+    if Regex.match?(@cmd_regex, text) do
+      do_run(user)
+    end
+  end
+
+  defp do_run(slack_id) do
+    user = Accounts.find_by(slack_id: slack_id)
+
+    beginning_of_week = Timex.now() |> Timex.beginning_of_week(:mon)
+
+    high_fives =
+      user.id
+      |> Feedback.high_fives_since(beginning_of_week)
+      |> to_paragraph()
+
+    reply = Messages.t("high_five.list", high_fives: high_fives)
+
+    {:reply, reply}
+  end
+
+  defp to_paragraph(high_fives) do
+    high_fives
+    |> Enum.map(fn high_five ->
+      sender = Accounts.find_by(id: high_five.sender_id)
+
+      "* From: <@#{sender.slack_id}>: #{high_five.reason}"
+    end)
+    |> Enum.join("\n")
+  end
+end

--- a/test/corker/slack/actions/list_test.exs
+++ b/test/corker/slack/actions/list_test.exs
@@ -1,0 +1,51 @@
+defmodule Corker.Slack.Actions.WeeklyListTest do
+  use Corker.DataCase, async: true
+
+  alias Corker.Slack.Actions
+
+  describe "run/1" do
+    test "ignores if the command is invalid" do
+      assert nil == Actions.WeeklyList.run(%{text: "just a command", user: "123"})
+    end
+
+    test "returns a message with the reasons from this week's high fives" do
+      receiver = insert(:user)
+      high_fives = insert_list(2, :high_five, receiver_id: receiver.id)
+
+      {:reply, reply} =
+        Actions.WeeklyList.run(%{text: "list my high fives", user: receiver.slack_id})
+
+      for high_five <- high_fives do
+        assert String.contains?(reply, high_five.reason)
+      end
+    end
+
+    test "ignores old high fives" do
+      receiver = insert(:user)
+      two_weeks_ago = Timex.now() |> Timex.shift(weeks: -2)
+      new_high_five = insert(:high_five, receiver_id: receiver.id)
+
+      old_high_five =
+        insert(:high_five, receiver_id: receiver.id, inserted_at: two_weeks_ago)
+
+      {:reply, reply} =
+        Actions.WeeklyList.run(%{text: "list my high fives", user: receiver.slack_id})
+
+      assert String.contains?(reply, new_high_five.reason)
+      refute String.contains?(reply, old_high_five.reason)
+    end
+
+    test "ignores other user's high fives" do
+      user = insert(:user)
+      another_user = insert(:user)
+      user_high_five = insert(:high_five, receiver_id: user.id)
+      other_high_five = insert(:high_five, receiver_id: another_user.id)
+
+      {:reply, reply} =
+        Actions.WeeklyList.run(%{text: "list my high fives", user: user.slack_id})
+
+      assert String.contains?(reply, user_high_five.reason)
+      refute String.contains?(reply, other_high_five.reason)
+    end
+  end
+end

--- a/test/corker/slack/actions_test.exs
+++ b/test/corker/slack/actions_test.exs
@@ -7,7 +7,7 @@ defmodule Corker.Slack.ActionsTest do
   }
 
   describe "parse/2" do
-    test "replies with error when receiving DMs" do
+    test "replies with error when receiving unknown DMs" do
       state = %{}
 
       response = Actions.parse(%{channel: "DIRECTMESSAGEID"}, state)


### PR DESCRIPTION
Why:

* We want users to be able to see their most recent high fives.

This change addresses the need by:

* Adding a command **only available via DM**: `list my high fives`.
* This command returns a message with the reasons and sender for the
high fives since the beginning of the week.