### PR TITLE
Remove the web server from the supervision tree in test

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -21,9 +21,10 @@ defmodule Corker.Application do
       %{
         id: Slack.Bot,
         start: {Slack.Bot, :start_link, [Corker.Slack, %{}, token]}
-      }
+      },
+      Corker.Web
     ] ++ base_children()
   end
 
-  defp base_children, do: [Corker.Repo, Corker.Web]
+  defp base_children, do: [Corker.Repo]
 end


### PR DESCRIPTION
Why:

* The web server was being spun in all environments.
* This meant that it tried to bind to a port whenever we ran a test.
* Besides the slow start up times for the tests, I believe the reason we
don't want this is pretty obvious.