### PR TITLE
Refactor stats to reports module

### DIFF
--- a/lib/corker/reports/monthly.ex
+++ b/lib/corker/reports/monthly.ex
@@ -1,0 +1,42 @@
+defmodule Corker.Reports.Monthly do
+  alias Corker.{
+    Accounts,
+    Feedback
+  }
+
+  def generate do
+    users = Accounts.all_users()
+
+    beginning_of_month = Timex.now() |> Timex.beginning_of_month()
+
+    users
+    |> high_five_count_since(beginning_of_month)
+    |> scrub_high_fives()
+  end
+
+  defp high_five_count_since(users, date) do
+    Enum.reduce(users, {%{}, %{}}, fn u, {senders, receivers} ->
+      high_fives = Feedback.high_fives_since(u.id, date)
+      new_receivers = Map.put(receivers, u.username, length(high_fives))
+      new_senders = update_senders(senders, high_fives)
+
+      {new_senders, new_receivers}
+    end)
+  end
+
+  defp update_senders(senders, high_fives) do
+    Enum.reduce(high_fives, senders, fn hf, acc ->
+      sender = Accounts.find_by(id: hf.sender_id)
+      Map.update(acc, sender.username, 1, &(&1 + 1))
+    end)
+  end
+
+  defp scrub_high_fives({senders, receivers}),
+    do: {scrub(senders), scrub(receivers)}
+
+  defp scrub(users) do
+    users
+    |> Enum.sort_by(fn {_u, count} -> count end, &>=/2)
+    |> Enum.take_while(fn {_u, count} -> count > 0 end)
+  end
+end

--- a/lib/corker/reports/weekly.ex
+++ b/lib/corker/reports/weekly.ex
@@ -1,0 +1,24 @@
+defmodule Corker.Reports.Weekly do
+  alias Corker.{
+    Accounts,
+    Feedback
+  }
+
+  def for(slack_id) do
+    user = Accounts.find_by(slack_id: slack_id)
+
+    beginning_of_week = Timex.now() |> Timex.beginning_of_week(:mon)
+
+    user.id
+    |> Feedback.high_fives_since(beginning_of_week)
+    |> compile_list()
+  end
+
+  defp compile_list(high_fives) do
+    Enum.map(high_fives, fn high_five ->
+      sender = Accounts.find_by(id: high_five.sender_id)
+
+      {sender.slack_id, high_five.reason}
+    end)
+  end
+end

--- a/lib/corker/slack/actions/monthly_stats.ex
+++ b/lib/corker/slack/actions/monthly_stats.ex
@@ -1,12 +1,8 @@
 defmodule Corker.Slack.Actions.MonthlyStats do
   @cmd_regex ~r/((give me|what are) the monthly stats)/
 
+  alias Corker.Reports
   alias Corker.Slack.Messages
-
-  alias Corker.{
-    Accounts,
-    Feedback
-  }
 
   def run(%{text: text}) do
     if Regex.match?(@cmd_regex, text),
@@ -14,14 +10,8 @@ defmodule Corker.Slack.Actions.MonthlyStats do
   end
 
   defp do_run do
-    users = Accounts.all_users()
-
-    beginning_of_month = Timex.now() |> Timex.beginning_of_month()
-
     {sender_stats, receiver_stats} =
-      users
-      |> high_five_count_since(beginning_of_month)
-      |> scrub_high_fives()
+      Reports.Monthly.generate()
       |> to_paragraph()
 
     sender_str =
@@ -33,32 +23,6 @@ defmodule Corker.Slack.Actions.MonthlyStats do
     reply = sender_str <> "\n\n" <> receiver_str
 
     {:reply, reply}
-  end
-
-  defp high_five_count_since(users, date) do
-    Enum.reduce(users, {%{}, %{}}, fn u, {senders, receivers} ->
-      high_fives = Feedback.high_fives_since(u.id, date)
-      new_receivers = Map.put(receivers, u.username, length(high_fives))
-      new_senders = update_senders(senders, high_fives)
-
-      {new_senders, new_receivers}
-    end)
-  end
-
-  defp update_senders(senders, high_fives) do
-    Enum.reduce(high_fives, senders, fn hf, acc ->
-      sender = Accounts.find_by(id: hf.sender_id)
-      Map.update(acc, sender.username, 1, &(&1 + 1))
-    end)
-  end
-
-  defp scrub_high_fives({senders, receivers}),
-    do: {scrub(senders), scrub(receivers)}
-
-  defp scrub(users) do
-    users
-    |> Enum.sort_by(fn {_u, count} -> count end, &>=/2)
-    |> Enum.take_while(fn {_u, count} -> count > 0 end)
   end
 
   defp to_paragraph({sender_stats, receiver_stats}) do

--- a/lib/corker/slack/actions/weekly_list.ex
+++ b/lib/corker/slack/actions/weekly_list.ex
@@ -1,12 +1,8 @@
 defmodule Corker.Slack.Actions.WeeklyList do
   @cmd_regex ~r/(list my high fives)/
 
+  alias Corker.Reports
   alias Corker.Slack.Messages
-
-  alias Corker.{
-    Accounts,
-    Feedback
-  }
 
   def run(%{text: text, user: user}) do
     if Regex.match?(@cmd_regex, text) do
@@ -15,13 +11,9 @@ defmodule Corker.Slack.Actions.WeeklyList do
   end
 
   defp do_run(slack_id) do
-    user = Accounts.find_by(slack_id: slack_id)
-
-    beginning_of_week = Timex.now() |> Timex.beginning_of_week(:mon)
-
     high_fives =
-      user.id
-      |> Feedback.high_fives_since(beginning_of_week)
+      slack_id
+      |> Reports.Weekly.for()
       |> to_paragraph()
 
     reply = Messages.t("high_five.list", high_fives: high_fives)
@@ -29,12 +21,10 @@ defmodule Corker.Slack.Actions.WeeklyList do
     {:reply, reply}
   end
 
-  defp to_paragraph(high_fives) do
-    high_fives
-    |> Enum.map(fn high_five ->
-      sender = Accounts.find_by(id: high_five.sender_id)
-
-      "From: <@#{sender.slack_id}>: #{high_five.reason}"
+  defp to_paragraph(report) do
+    report
+    |> Stream.map(fn {sender_slack_id, reason} ->
+      "From: <@#{sender_slack_id}>: #{reason}"
     end)
     |> Enum.join("\n")
   end

--- a/test/corker/reports/monthly_test.exs
+++ b/test/corker/reports/monthly_test.exs
@@ -1,0 +1,61 @@
+defmodule Corker.Reports.MonthlyTest do
+  use Corker.DataCase, async: true
+
+  alias Corker.Reports.Monthly
+
+  describe "generate/0" do
+    test "returns the leaderboards for this month" do
+      top_sender = insert(:user)
+      top_receiver = insert(:user)
+      avg_user = insert(:user)
+      insert(:high_five, receiver_id: top_receiver.id, sender_id: top_sender.id)
+      insert(:high_five, receiver_id: top_receiver.id, sender_id: avg_user.id)
+      insert(:high_five, receiver_id: avg_user.id, sender_id: top_sender.id)
+
+      {sender_stats, receiver_stats} = Monthly.generate()
+
+      assert [
+               {top_sender.username, 2},
+               {avg_user.username, 1}
+             ] == sender_stats
+
+      assert [
+               {top_receiver.username, 2},
+               {avg_user.username, 1}
+             ] == receiver_stats
+    end
+
+    test "ignores old high fives" do
+      sender = insert(:user)
+      old_receiver = insert(:user)
+      new_receiver = insert(:user)
+      two_months_ago = Timex.now() |> Timex.shift(months: -2)
+
+      _new_high_five =
+        insert(:high_five, receiver_id: new_receiver.id, sender_id: sender.id)
+
+      _old_high_five =
+        insert(:high_five,
+          receiver_id: old_receiver.id,
+          sender_id: sender.id,
+          inserted_at: two_months_ago
+        )
+
+      {_sender_stats, receiver_stats} = Monthly.generate()
+
+      assert [{new_receiver.username, 1}] == receiver_stats
+    end
+
+    test "ignores users who haven't given or received high fives" do
+      sender = insert(:user)
+      receiver = insert(:user)
+      _other_user = insert(:user)
+      insert(:high_five, receiver_id: receiver.id, sender_id: sender.id)
+
+      {sender_stats, receiver_stats} = Monthly.generate()
+
+      assert [{receiver.username, 1}] == receiver_stats
+      assert [{sender.username, 1}] == sender_stats
+    end
+  end
+end

--- a/test/corker/reports/weekly_test.exs
+++ b/test/corker/reports/weekly_test.exs
@@ -1,0 +1,65 @@
+defmodule Corker.Reports.WeeklyTest do
+  use Corker.DataCase, async: true
+
+  alias Corker.Reports.Weekly
+
+  describe "for/1" do
+    test "returns a list of the sender and reason for the high five" do
+      receiver = insert(:user)
+      sender = insert(:user)
+
+      high_fives =
+        insert_list(2, :high_five,
+          receiver_id: receiver.id,
+          sender_id: sender.id
+        )
+
+      report = Weekly.for(receiver.slack_id)
+
+      assert report ==
+               for(
+                 high_five <- high_fives,
+                 do: {sender.slack_id, high_five.reason}
+               )
+    end
+
+    test "ignores old high fives" do
+      sender = insert(:user)
+      receiver = insert(:user)
+      two_weeks_ago = Timex.now() |> Timex.shift(weeks: -2)
+
+      new_high_five =
+        insert(:high_five, receiver_id: receiver.id, sender_id: sender.id)
+
+      _old_high_five =
+        insert(:high_five,
+          receiver_id: receiver.id,
+          sender_id: sender.id,
+          inserted_at: two_weeks_ago
+        )
+
+      report = Weekly.for(receiver.slack_id)
+
+      assert [{sender.slack_id, new_high_five.reason}] == report
+    end
+
+    test "ignores other user's high fives" do
+      sender = insert(:user)
+      receiver = insert(:user)
+      another_receiver = insert(:user)
+
+      receiver_high_five =
+        insert(:high_five, receiver_id: receiver.id, sender_id: sender.id)
+
+      _other_high_five =
+        insert(:high_five,
+          receiver_id: another_receiver.id,
+          sender_id: sender.id
+        )
+
+      report = Weekly.for(receiver.slack_id)
+
+      assert [{sender.slack_id, receiver_high_five.reason}] == report
+    end
+  end
+end

--- a/test/corker/slack/actions/monthly_stats_test.exs
+++ b/test/corker/slack/actions/monthly_stats_test.exs
@@ -1,15 +1,14 @@
 defmodule Corker.Slack.Actions.MonthlyStatsTest do
   use Corker.DataCase, async: true
 
-  alias Corker.Slack.Actions
+  alias Corker.Slack.Actions.MonthlyStats
 
   describe "run/1" do
     test "ignores if the command is invalid" do
-      assert nil ==
-               Actions.WeeklyList.run(%{text: "just a command", user: "123"})
+      assert nil == MonthlyStats.run(%{text: "just a command", user: "123"})
     end
 
-    test "returns a message with the leaderboard for this month" do
+    test "correctly formats the leaderboards" do
       top_sender = insert(:user)
       top_receiver = insert(:user)
       avg_user = insert(:user)
@@ -17,8 +16,7 @@ defmodule Corker.Slack.Actions.MonthlyStatsTest do
       insert(:high_five, receiver_id: top_receiver.id, sender_id: avg_user.id)
       insert(:high_five, receiver_id: avg_user.id, sender_id: top_sender.id)
 
-      {:reply, reply} =
-        Actions.MonthlyStats.run(%{text: "what are the monthly stats"})
+      {:reply, reply} = MonthlyStats.run(%{text: "what are the monthly stats"})
 
       # sender leaderboard
       assert String.contains?(
@@ -37,41 +35,6 @@ defmodule Corker.Slack.Actions.MonthlyStatsTest do
                2. #{avg_user.username} - 1\
                """
              )
-    end
-
-    test "ignores old high fives" do
-      sender = insert(:user)
-      old_receiver = insert(:user)
-      new_receiver = insert(:user)
-      two_months_ago = Timex.now() |> Timex.shift(months: -2)
-
-      _new_high_five =
-        insert(:high_five, receiver_id: new_receiver.id, sender_id: sender.id)
-
-      _old_high_five =
-        insert(:high_five,
-          receiver_id: old_receiver.id,
-          sender_id: sender.id,
-          inserted_at: two_months_ago
-        )
-
-      {:reply, reply} =
-        Actions.MonthlyStats.run(%{text: "give me the monthly stats"})
-
-      assert String.contains?(reply, "1. #{new_receiver.username} - 1")
-      refute String.contains?(reply, old_receiver.username)
-    end
-
-    test "ignores users who haven't given or received high fives" do
-      sender = insert(:user)
-      receiver = insert(:user)
-      other_user = insert(:user)
-      insert(:high_five, receiver_id: receiver.id, sender_id: sender.id)
-
-      {:reply, reply} =
-        Actions.MonthlyStats.run(%{text: "give me the monthly stats"})
-
-      refute String.contains?(reply, other_user.username)
     end
   end
 end


### PR DESCRIPTION
Why:

* Some of the code for the report is relevant for automated messages
running on cron jobs.
* To avoid duplication this should be extracted.

This change addresses the need by:

* Extracting the code to a reports module.
* Updating the slack actions to use those same reports.