### PR TITLE
Add private high fives

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,6 @@ config :corker, :slack, oauth_token: {:system, "SLACK_BOT_OAUTH_TOKEN"}
 
 config :corker, Corker.Jobs.Report, channel: "#bottest"
 
-config :corker, :high_fives,
-  self_fives: false
+config :corker, Corker.Slack.HighFives, self_fives: false
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,4 +7,4 @@ config :corker, Corker.Repo,
   hostname: "localhost",
   pool_size: 10
 
-config :corker, :high_fives, self_fives: true
+config :corker, Corker.Slack.HighFives, self_fives: true

--- a/config/messages.yml
+++ b/config/messages.yml
@@ -10,6 +10,10 @@ high_five:
     receiver_not_found: "Hm, it appears I can't high five <@<%= slack_id %>>. It's either a bot user or someone I don't know yet."
     self_five: "Now now, you know you shouldn't self five."
 
+private_high_five:
+  created:
+    "Oh boy! <%= sender_username %> just sent you a high five <%= reason %>"
+
 reports:
   monthly:
     prefix: "HEAR YE, HEAR YE! It is the time of the month to congratulate the most lovable people!"

--- a/lib/corker/slack/actions.ex
+++ b/lib/corker/slack/actions.ex
@@ -6,7 +6,8 @@ defmodule Corker.Slack.Actions do
   ]
 
   @dm_actions [
-    __MODULE__.WeeklyList
+    __MODULE__.WeeklyList,
+    __MODULE__.PrivateHighFive
     | @shared_actions
   ]
 

--- a/lib/corker/slack/high_fives.ex
+++ b/lib/corker/slack/high_fives.ex
@@ -1,0 +1,28 @@
+defmodule Corker.Slack.HighFives do
+  @self_fives_allowed Application.get_env(:corker, __MODULE__)[:self_fives]
+
+  alias Corker.{
+    Accounts,
+    Feedback
+  }
+
+  def create(receiver_slack_id, sender_slack_id, reason) do
+    sender = Accounts.find_by(slack_id: sender_slack_id)
+    receiver = Accounts.find_by(slack_id: receiver_slack_id)
+
+    cond do
+      is_nil(receiver) ->
+        {:error, :no_receiver}
+
+      receiver_slack_id == sender_slack_id and not @self_fives_allowed ->
+        {:error, :self_five}
+
+      true ->
+        Feedback.create_high_five(%{
+          sender_id: sender.id,
+          receiver_id: receiver.id,
+          reason: reason
+        })
+    end
+  end
+end

--- a/lib/corker/slack/users.ex
+++ b/lib/corker/slack/users.ex
@@ -1,6 +1,4 @@
 defmodule Corker.Slack.Users do
-  use Task
-
   alias Corker.Accounts
 
   @slackbot_id "USLACKBOT"

--- a/test/corker/slack/actions/high_five_test.exs
+++ b/test/corker/slack/actions/high_five_test.exs
@@ -71,7 +71,7 @@ defmodule Corker.Slack.Actions.HighFiveTest do
 
       assert {:reply, reply} == response
 
-      Application.put_env(:corker, :high_fives, [opts])
+      Application.put_env(:corker, :high_fives, opts)
     end
   end
 end


### PR DESCRIPTION
If a user chooses to send a high five via DM with corker, the high five
won't be posted publicly but the receiver will get a message containing
the sender and the reason for it.

Note:

* This is missing tests
* This depends on #18